### PR TITLE
add a context to all http requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,5 +1,7 @@
 package voicebase
 
+import "context"
+
 type Client struct {
 	Media MediaClient
 }
@@ -13,18 +15,18 @@ func getC() *Client {
 }
 
 // UploadMedia uploads a media to voicebase for transcribing.
-func UploadMedia(url string) (string, error) {
-	return DefaultClient.Media.Upload(url)
+func UploadMedia(ctx context.Context, url string) (string, error) {
+	return DefaultClient.Media.Upload(ctx, url)
 }
 
 // GetMedia returns a media from voicebase with the appropriate ID.
-func GetMedia(id string) (*Media, error) {
-	return DefaultClient.Media.Get(id)
+func GetMedia(ctx context.Context, id string) (*Media, error) {
+	return DefaultClient.Media.Get(ctx, id)
 }
 
 // DeleteMedia enables deleting of media on voicebase identified by its ID.
-func DeleteMedia(id string) error {
-	return DefaultClient.Media.Delete(id)
+func DeleteMedia(ctx context.Context, id string) error {
+	return DefaultClient.Media.Delete(ctx, id)
 }
 
 func (c *Client) Init(bearerToken string) {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/sprucehealth/voicebase
+
+go 1.19

--- a/media.go
+++ b/media.go
@@ -2,6 +2,7 @@ package voicebase
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"mime/multipart"
 )
@@ -71,9 +72,9 @@ var voicemailOptimizedConfiguration = &Configuration{
 }
 
 type MediaClient interface {
-	Upload(url string) (string, error)
-	Get(id string) (*Media, error)
-	Delete(id string) error
+	Upload(ctx context.Context, url string) (string, error)
+	Get(ctx context.Context, id string) (*Media, error)
+	Delete(ctx context.Context, id string) error
 }
 
 type mediaClient struct {
@@ -88,7 +89,7 @@ func NewMediaClient(backend Backend, bearerToken string) MediaClient {
 	}
 }
 
-func (m mediaClient) Upload(url string) (string, error) {
+func (m mediaClient) Upload(ctx context.Context, url string) (string, error) {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 
@@ -106,22 +107,22 @@ func (m mediaClient) Upload(url string) (string, error) {
 	}
 
 	var media Media
-	if err := m.b.CallMultipart("POST", "media", m.bearerToken, writer.Boundary(), body, &media); err != nil {
+	if err := m.b.CallMultipart(ctx, "POST", "media", m.bearerToken, writer.Boundary(), body, &media); err != nil {
 		return "", err
 	}
 
 	return media.ID, nil
 }
 
-func (m mediaClient) Get(id string) (*Media, error) {
+func (m mediaClient) Get(ctx context.Context, id string) (*Media, error) {
 	var media Media
-	if err := m.b.Call("GET", "media/"+id, m.bearerToken, &media); err != nil {
+	if err := m.b.Call(ctx, "GET", "media/"+id, m.bearerToken, &media); err != nil {
 		return nil, err
 	}
 
 	return &media, nil
 }
 
-func (m mediaClient) Delete(id string) error {
-	return m.b.Call("DELETE", "media/"+id, m.bearerToken, nil)
+func (m mediaClient) Delete(ctx context.Context, id string) error {
+	return m.b.Call(ctx, "DELETE", "media/"+id, m.bearerToken, nil)
 }


### PR DESCRIPTION
Introduce a context for all http requests. This package was also not treated as a module since the concept of module predates this package. So ran `go mod init` to treat it as a module.