### PR TITLE
Fix error message parsing

### DIFF
--- a/error.go
+++ b/error.go
@@ -21,8 +21,15 @@ type Error struct {
 }
 
 func (e *Error) Error() string {
-	if len(e.Errors) > 0 {
-		return fmt.Sprintf("voicebase: status=%d %s: %s", e.Status, e.Reference, e.Errors[0].Error)
+	errStr := fmt.Sprintf("voicebase: status=%d %s: ", e.Status, e.Reference)
+	for i, err := range e.Errors {
+		if i > 0 {
+			errStr += ", "
+		}
+		errStr += err.Error
 	}
-	return ""
+	for _, warn := range e.Warnings {
+		errStr += fmt.Sprintf(", warning (code %d @ %s): %s", warn.Code, warn.Path, warn.Message)
+	}
+	return errStr
 }

--- a/error.go
+++ b/error.go
@@ -6,13 +6,23 @@ type ErrorItem struct {
 	Error string `json:"error"`
 }
 
+type Message struct {
+	Code    int    `json:"code"`
+	Path    string `json:"path"`
+	Message string `json:"message"`
+}
+
 // Error is a structured response indicating a non-2xx HTTP response.
 type Error struct {
-	Errors    ErrorItem `json:"errors"`
+	Warnings  []Message `json:"warnings"`
+	Errors    []ErrorItem `json:"errors"`
 	Reference string    `json:"reference"`
 	Status    int       `json:"status"`
 }
 
 func (e *Error) Error() string {
-	return fmt.Sprintf("voicebase: status=%d %s: %s", e.Status, e.Reference, e.Errors.Error)
+	if len(e.Errors) > 0 {
+		return fmt.Sprintf("voicebase: status=%d %s: %s", e.Status, e.Reference, e.Errors[0].Error)
+	}
+	return ""
 }


### PR DESCRIPTION
I'm guessing the error message parsing was broken when we migrated to v3 and that we just don't rely on it. Can see the error message format in the 403 here: https://docs.voicebase.com/reference/postmedia